### PR TITLE
refactor: Agriculture User and Agriculture Manager moved to the app

### DIFF
--- a/agriculture/agriculture/agriculture.py
+++ b/agriculture/agriculture/agriculture.py
@@ -1,3 +1,0 @@
-data = {
-	'on_setup': 'agriculture.agriculture.setup.setup_agriculture'
-}

--- a/agriculture/agriculture/setup.py
+++ b/agriculture/agriculture/setup.py
@@ -7,6 +7,7 @@ def setup_agriculture():
 		# already setup
 		return
 	create_agriculture_data()
+	add_additional_permissions()
 
 def create_agriculture_data():
 	records = [
@@ -427,3 +428,32 @@ def create_agriculture_data():
 			linked_doctype='Weather')
 	]
 	insert_record(records)
+
+def add_additional_permissions():
+	frappe.get_doc({
+		"doctype": "Custom DocPerm",
+		"parent": "Location",
+		"role": "Agriculture Manager",
+		"create": 1,
+		"delete": 1,
+		"email": 1,
+		"export": 1,
+		"print": 1,
+		"read": 1,
+		"report": 1,
+		"share": 1,
+		"write": 1
+	}).insert()
+
+	frappe.get_doc({
+		"doctype": "Custom DocPerm",
+		"parent": "Location",
+		"role": "Agriculture User",
+		"email": 1,
+		"export": 1,
+		"print": 1,
+		"read": 1,
+		"report": 1,	
+		"share": 1,
+		"write": 1
+	}).insert()

--- a/agriculture/agriculture/setup.py
+++ b/agriculture/agriculture/setup.py
@@ -457,3 +457,9 @@ def add_additional_permissions():
 		"share": 1,
 		"write": 1
 	}).insert()
+
+def cleanup_role_and_permissions():
+	for role in ["Agriculture Manager", "Agriculture User"]:
+		frappe.db.delete("Custom DocPerm", {"role": role})
+		frappe.db.delete("Role", role)
+	frappe.db.commit()

--- a/agriculture/hooks.py
+++ b/agriculture/hooks.py
@@ -69,7 +69,7 @@ required_apps = ["erpnext"]
 # ------------
 
 # before_install = "agriculture.install.before_install"
-# after_install = "agriculture.install.after_install"
+after_install = "agriculture.agriculture.setup.setup_agriculture"
 
 # Uninstallation
 # ------------

--- a/agriculture/hooks.py
+++ b/agriculture/hooks.py
@@ -75,7 +75,7 @@ after_install = "agriculture.agriculture.setup.setup_agriculture"
 # ------------
 
 # before_uninstall = "agriculture.uninstall.before_uninstall"
-# after_uninstall = "agriculture.uninstall.after_uninstall"
+after_uninstall = "agriculture.agriculture.setup.cleanup_role_and_permissions"
 
 # Desk Notifications
 # ------------------


### PR DESCRIPTION
This PR adds permissions for the doctype `Location` of roles "Agriculture User" and "Agriculture Manager"  which are set to be removed from ERPNext by https://github.com/frappe/erpnext/pull/47335.

I have added them as `Custom DocPerm` as the `doctype` `Location` is still part of ERPNext. 
Addition and cleanup of the `permission`are added as `hooks`.

